### PR TITLE
Respect font-lock-mode nil.

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -4556,7 +4556,15 @@ This is an exact copy of `line-number-at-pos' for use in emacs21."
            markdown-mode-font-lock-keywords-basic
            markdown-mode-font-lock-keywords-core))
     (setq font-lock-defaults '(markdown-mode-font-lock-keywords))
-    (when (fboundp 'font-lock-refresh-defaults) (font-lock-refresh-defaults))))
+    (when (fboundp 'font-lock-refresh-defaults)
+      ;; font-lock-refresh-defaults can set font-lock-mode to t even
+      ;; if global-font-lock-mode and font-lock-global-modes are nil.
+      ;; So save the original value of font-lock-mode and set it back
+      ;; to nil if it was nil to begin with.
+      (let ((save-font-lock-mode font-lock-mode))
+        (font-lock-refresh-defaults)
+        (when (not save-font-lock-mode)
+          (font-lock-mode -1))))))
 
 (defun markdown-enable-math (&optional arg)
   "Toggle support for inline and display LaTeX math expressions.


### PR DESCRIPTION
font-lock-refresh-defaults can set font-lock-mode to t even if global-font-lock-mode and font-lock-global-modes are nil. So save the original value of font-lock-mode and set it back to nil if it was nil to begin with.

This is probably an issue with font-lock-refresh-defaults but this hack makes markdown-mode readable for me.