### PR TITLE
Console Emacs -friendly backspace/tab bindings

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -3505,11 +3505,11 @@ Assumes match data is available for `markdown-regex-italic'."
     (define-key map (kbd "C-c C-j") 'markdown-jump)
     ;; Indentation
     (define-key map (kbd "C-m") 'markdown-enter-key)
-    (define-key map (kbd "<backspace>") 'markdown-exdent-or-delete)
+    (define-key map (kbd "DEL") 'markdown-exdent-or-delete)
     (define-key map (kbd "C-c >") 'markdown-indent-region)
     (define-key map (kbd "C-c <") 'markdown-exdent-region)
     ;; Visibility cycling
-    (define-key map (kbd "<tab>") 'markdown-cycle)
+    (define-key map (kbd "TAB") 'markdown-cycle)
     (define-key map (kbd "<S-iso-lefttab>") 'markdown-shifttab)
     (define-key map (kbd "<S-tab>")  'markdown-shifttab)
     (define-key map (kbd "<backtab>") 'markdown-shifttab)


### PR DESCRIPTION
This commit fixes a couple of bindings so that they work in console
Emacs (i.e. `emacs -nw`) as well as GUI Emacs.

Incidentally, this also improves interoperability with evil-mode,
since before this commit <backspace> remained bound in evil's Normal
State (where usually <backspace>, or rather DEL, would be bound to
`evil-backward-char'.