### PR TITLE
Only call font-lock-refresh-defaults if font-lock-mode is non-nil.

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -5745,7 +5745,9 @@ This is an exact copy of `line-number-at-pos' for use in emacs21."
           '(markdown-mode-font-lock-keywords
             nil nil nil nil
             (font-lock-syntactic-face-function . markdown-syntactic-face)))
-    (when (fboundp 'font-lock-refresh-defaults) (font-lock-refresh-defaults))))
+    (when (and font-lock-mode
+               (fboundp 'font-lock-refresh-defaults))
+      (font-lock-refresh-defaults))))
 
 (defun markdown-enable-math (&optional arg)
   "Toggle support for inline and display LaTeX math expressions.


### PR DESCRIPTION
Otherwise font-lock-mode will be enabled even if the user has disabled it.
