### PR TITLE
use non-greedy *? for display math content

### DIFF
--- a/markdown-mode.el
+++ b/markdown-mode.el
@@ -1442,7 +1442,7 @@ Groups 1 and 3 match opening and closing dollar signs.
 Group 3 matches the mathematical expression contained within.")
 
 (defconst markdown-regex-math-display
-  "^\\(\\\\\\[\\)\\(\\(?:.\\|\n\\)*\\)?\\(\\\\\\]\\)$"
+  "^\\(\\\\\\[\\)\\(\\(?:.\\|\n\\)*?\\)?\\(\\\\\\]\\)$"
   "Regular expression for itex \[..\] display mode expressions.
 Groups 1 and 3 match the opening and closing delimiters.
 Group 2 matches the mathematical expression contained within.")


### PR DESCRIPTION
Using greedy `*` means that the regex will match across display math blocks. For example, the current regex matches this whole snippet (including the non-math bit in the middle):

```
\[
some math
\]
non-math
\[
more math
\]
```

The only potential downside I can see is that if, for some strange reason, someone wants a literal `\]` inside their display math block, the regex will think that the block ends early. But this seems less likely than the frustrating situation of having non-math font-locked as math in between two display math blocks (which is very common in my documents).